### PR TITLE
updated spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# accounts-multply
+# accounts-multiply
 ----
 
 This package allows you to support having multiple OAuth accounts from a single service under one user account in your Meteor application.

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'rkstar:accounts-multiply',
-  version: '1.1.1',
+  version: '1.1.2',
   summary: 'Support merging multiple login services to a single account in a Meteor app.',
   git: 'https://github.com/rkstar/accounts-multiply.git',
   documentation: 'README.md'


### PR DESCRIPTION
added the missing “i” from “multiply”
